### PR TITLE
Fixed mistakes in SD_of_mathematical_tasks

### DIFF
--- a/SD_of_mathematical_tasks/concept_approximation.scs
+++ b/SD_of_mathematical_tasks/concept_approximation.scs
@@ -1,0 +1,47 @@
+concept_approximation
+=>nrel_inclusion:concept_mathematical_tasks;
+<-sc_node_not_relation;
+
+=>nrel_main_idtf:
+[приближение](*<-lang_ru;;*);
+[approximation](*<-lang_en;;*);
+
+=>nrel_idtf:
+[аппроксимация](*<-lang_ru;;*);
+
+<- rrel_key_sc_element: ...
+(*
+<- definition;;
+=> nrel_main_idtf:
+      [Опр. (приближение)] (* <- lang_ru;; *);;
+=> nrel_using_constants: 
+	{
+ 		object;
+		concept_scientific_method
+	};; 
+<= nrel_sc_text_translation: ... 
+		(*
+			->rrel_example:
+			[Приближение - это <b><sc_element sys_idtf="concept_scientific_method">научный метод</b>, состоящий в замене одних <b><sc_element sys_idtf="object">объектов</b> другими, в каком-то смысле близкими к исходным но более простым.](*<- lang_ru;; =>nrel_format: format_html;;*);;
+		*);;
+*);
+
+
+<- rrel_key_sc_element: ... 
+(*
+ => nrel_main_idtf:
+[Утв. 1 (приближение)] (* <- lang_ru;; *);;
+ <= nrel_sc_text_translation: ...
+	 (*
+    	  -> rrel_example:
+		[<b><sc_element sys_idtf="task">Задачу</b> приближения решают когда точное <b><sc_element sys_idtf="value">значение</b> получить нельзя или слишком проблематично.](*<-lang_ru;; =>nrel_format: format_html;;*);;
+	*);;
+=> nrel_using_constants: 
+{
+task;
+value
+};;
+*);
+
+<-rrel_explored_concept: section_subject_domain_of_mathematical_tasks;;
+

--- a/SD_of_mathematical_tasks/concept_decrease_in_dimension.scs
+++ b/SD_of_mathematical_tasks/concept_decrease_in_dimension.scs
@@ -1,0 +1,46 @@
+concept_decrease_in_dimension
+<-sc_node_not_relation;
+=>nrel_inclusion:concept_mathematical_tasks;
+
+=>nrel_main_idtf:
+[уменьшение в размере](*<-lang_ru;;*);
+[decrease in dimension](*<-lang_en;;*);
+
+<- rrel_key_sc_element: ...
+(*
+<- definition;;
+=> nrel_main_idtf:
+      [Опр. (уменьшение в размере)] (* <- lang_ru;; *);;
+=> nrel_using_constants: 
+	{
+		task;
+		weight;
+		data
+
+	};; 
+<= nrel_sc_text_translation: ... 
+		(*
+			->rrel_example:
+			[Уменьшение в размере - это <b><sc_element sys_idtf="concept_mathematical_tasks">математическая задача</b>, включающая в себя уменьшение <b><sc_element sys_idtf="weight">веса</b> больших массивов <b><sc_element sys_idtf="data">данных</b>.](*<- lang_ru;; =>nrel_format: format_html;;*);;
+		*);;
+*);
+
+<- rrel_key_sc_element: ... 
+(*
+ => nrel_main_idtf:
+[Утв. 1 (уменьшение в размере)] (* <- lang_ru;; *);;
+ <= nrel_sc_text_translation: ...
+	 (*
+    	  -> rrel_example:
+		[Уменьшение в размере - одна из <b><sc_element sys_idtf="task">задач</b>, решаемых с помощью <b><sc_element sys_idtf="concept_neural_network_in_graphical_representation">искусственных нейронных сетей</b>.](*<-lang_ru;; =>nrel_format: format_html;;*);;
+	*);;
+=> nrel_using_constants: 
+{
+task;
+concept_neural_network_in_graphical_representation
+};;
+*);
+
+<-rrel_explored_concept: section_subject_domain_of_mathematical_tasks;;
+
+

--- a/SD_of_mathematical_tasks/concept_extrapolation.scs
+++ b/SD_of_mathematical_tasks/concept_extrapolation.scs
@@ -1,0 +1,46 @@
+concept_extrapolation
+<-sc_node_not_relation;
+=>nrel_inclusion:concept_mathematical_tasks;
+
+=>nrel_main_idtf:
+[экстраполяция](*<-lang_ru;;*);
+[extrapolation](*<-lang_en;;*);
+
+<- rrel_key_sc_element: ...
+(*
+<- definition;;
+=> nrel_main_idtf:
+      [Опр. (экстраполяция)] (* <- lang_ru;; *);;
+=> nrel_using_constants: 
+	{
+		process;
+		object;
+		set
+
+	};; 
+<= nrel_sc_text_translation: ... 
+		(*
+			->rrel_example:
+			[Экстраполяция - это логическая методологическая <b><sc_element sys_idtf="process">процедура</b> распространения выводов, сделанных относительно какой-либо части <b><sc_element sys_idtf="object">объектов</b> на всё <b><sc_element sys_idtf="set">множество</b> данных объектов или явлений, а также на их другую какую-либо часть.](*<- lang_ru;; =>nrel_format: format_html;;*);;
+		*);;
+*);
+
+
+<- rrel_key_sc_element: ... 
+(*
+ => nrel_main_idtf:
+[Утв. 1 (экстраполяция)] (* <- lang_ru;; *);;
+ <= nrel_sc_text_translation: ...
+	 (*
+    	  -> rrel_example:
+		[Частичным <b><sc_element sys_idtf="nrel_synonymy">синонимом</b> экстраполяции является понятие <b><sc_element sys_idtf="concept_identify_a_tendency">выявлять тенденцию</b>.](*<-lang_ru;; =>nrel_format: format_html;;*);;
+	*);;
+=> nrel_using_constants: 
+{
+nrel_synonymy;
+concept_identify_a_tendency
+};;
+*);
+
+<-rrel_explored_concept: section_subject_domain_of_mathematical_tasks;;
+

--- a/SD_of_mathematical_tasks/concept_increase_in_dimension.scs
+++ b/SD_of_mathematical_tasks/concept_increase_in_dimension.scs
@@ -1,0 +1,44 @@
+concept_increase_in_dimension
+<-sc_node_not_relation;
+=>nrel_inclusion:concept_mathematical_tasks;
+
+=>nrel_main_idtf:
+[увелечение в размере](*<-lang_ru;;*);
+[increase in dimension](*<-lang_en;;*);
+
+<- rrel_key_sc_element: ...
+(*
+<- definition;;
+=> nrel_main_idtf:
+      [Опр. (увелечение в размере)] (* <- lang_ru;; *);;
+=> nrel_using_constants: 
+	{
+		concept_mathematical_tasks;
+		data
+
+	};; 
+<= nrel_sc_text_translation: ... 
+		(*
+			->rrel_example:
+			[Увелечение в размере - это <b><sc_element sys_idtf="concept_mathematical_tasks">математическая задача</b>, включающая расшифровку сжатых <b><sc_element sys_idtf="data">данных</b>.](*<- lang_ru;; =>nrel_format: format_html;;*);;
+		*);;
+*);
+
+
+<- rrel_key_sc_element: ... 
+(*
+ => nrel_main_idtf:
+[Утв. 1 о увелечение в размере.] (* <- lang_ru;; *);;
+ <= nrel_sc_text_translation: ...
+	 (*
+    	  -> rrel_example:
+		[Увелечение в размере - одна из <b><sc_element sys_idtf="task">задач</b>, решаемых с помощью <b><sc_element sys_idtf="concept_neural_network_in_graphical_representation">иcкусственных нейронных сетей</b>.](*<-lang_ru;; =>nrel_format: format_html;;*);;
+	*);;
+=> nrel_using_constants: 
+{
+task;
+concept_neural_network_in_graphical_representation
+};;
+*);
+
+<-rrel_explored_concept: section_subject_domain_of_mathematical_tasks;;

--- a/SD_of_mathematical_tasks/concept_increase_in_dimension.scs
+++ b/SD_of_mathematical_tasks/concept_increase_in_dimension.scs
@@ -28,7 +28,7 @@ concept_increase_in_dimension
 <- rrel_key_sc_element: ... 
 (*
  => nrel_main_idtf:
-[Утв. 1 о увелечение в размере.] (* <- lang_ru;; *);;
+[Утв. 1 (увелечение в размере)] (* <- lang_ru;; *);;
  <= nrel_sc_text_translation: ...
 	 (*
     	  -> rrel_example:

--- a/SD_of_mathematical_tasks/concept_information_compression.scs
+++ b/SD_of_mathematical_tasks/concept_information_compression.scs
@@ -1,0 +1,52 @@
+concept_information_compression
+=>nrel_inclusion:concept_mathematical_tasks;
+<-sc_node_not_relation;
+
+=>nrel_main_idtf:
+[сжатие информации](*<-lang_ru;;*);
+[information compression](*<-lang_en;;*);
+
+<-rrel_key_sc_element:...
+(*
+<-definition;;
+=> nrel_main_idtf: [Опр. (сжатие информации)](*<- lang_ru;;*);;
+
+=> nrel_using_constants:
+{ 
+	algorithmic_data_conversion;
+	concept_decrease_in_dimension;
+	nrel_volume_of_data
+};;
+<= nrel_sc_text_translation: ...
+	(*
+		->rrel_example:
+		[Сжатие информации — <b><sc_element sys_idtf="algorithmic_data_conversion">алгоритмическое преобразование данных</b> (кодирование), при котором за счет<b><sc_element sys_idtf="concept_decrease_in_dimension"> уменьшения их избыточности</b> уменьшается их <b><sc_element sys_idtf="nrel_volume_of_data">обьём</b>.]
+(*<- lang_ru;; =>nrel_format: format_html;;*);;
+	*);;
+
+*);
+
+<-rrel_key_sc_element:...
+(*
+=> nrel_main_idtf: 
+	[Утв. 1 (сжатие информации)](*<- lang_ru;;*);;
+
+=> nrel_using_constants:
+	{
+		information_source_model;
+		method
+	};;
+<= nrel_sc_text_translation: ...
+			(*->rrel_example:[В основе любого <b><sc_element sys_idtf="method">способа</b> сжатия информации лежит <b><sc_element sys_idtf="information_source_model">модель источника информации</b>.](*<-lang_ru;; =>nrel_format: format_html;;*);;
+			*);;
+
+
+*);
+
+->rrel_example:some_information;
+
+=>nrel_inclusion:method;
+
+<-rrel_explored_concept: section_subject_domain_of_mathematical_tasks;;
+
+

--- a/SD_of_mathematical_tasks/concept_logical_inference.scs
+++ b/SD_of_mathematical_tasks/concept_logical_inference.scs
@@ -1,0 +1,48 @@
+concept_logical_inference
+<-sc_node_not_relation;
+=>nrel_inclusion:concept_mathematical_tasks;
+=>nrel_inclusion:concept_conceptually_pragmatic_tasks;
+
+=>nrel_main_idtf:
+[логический интерфейс](*<-lang_ru;;*);
+[logical inference](*<-lang_en;;*);
+
+<- rrel_key_sc_element: ...
+(*
+<- definition;;
+=> nrel_main_idtf:
+      [Опр. (логический интерфейс)] (* <- lang_ru;; *);;
+=> nrel_using_constants: 
+	{
+		format;
+		program;
+		concept_message
+	};; 
+<= nrel_sc_text_translation: ... 
+		(*
+			->rrel_example:
+			[Логический интерфейс - это  набор  <b><sc_element sys_idtf="concept_message">информационных сообщений</b> определённого <b><sc_element sys_idtf="format">формата</b>, которыми обмениваются два устройства или две <b><sc_element sys_idtf="program">программы</b>, а также набор правил, определяющих логику обмена этими сообщениями.](*<- lang_ru;; =>nrel_format: format_html;;*);;
+		*);;
+*);
+
+
+<- rrel_key_sc_element: ... 
+(*
+ => nrel_main_idtf:
+[Утв. 1 (логический интерфейс)] (* <- lang_ru;; *);;
+ <= nrel_sc_text_translation: ...
+	 (*
+    	  -> rrel_example:
+		[Создание логического интерфейса - одна из  <b><sc_element sys_idtf="task">задач</b>,  решаемых <b><sc_element sys_idtf="concept_neural_network_in_graphical_representation">искусственными нейронными сетями</b>.](*<-lang_ru;; =>nrel_format: format_html;;*);;
+	*);;
+=> nrel_using_constants: 
+{
+concept_neural_network_in_graphical_representation;
+task
+};;
+*);
+
+<-rrel_explored_concept: section_subject_domain_of_mathematical_tasks;;
+
+
+

--- a/SD_of_mathematical_tasks/concept_optimization.scs
+++ b/SD_of_mathematical_tasks/concept_optimization.scs
@@ -1,0 +1,45 @@
+concept_optimization
+<-sc_node_not_relation;
+=>nrel_inclusion:concept_mathematical_tasks;
+
+=>nrel_main_idtf:
+[оптимизация](*<-lang_ru;;*);
+[optimization](*<-lang_en;;*);
+
+<- rrel_key_sc_element: ...
+(*
+<- definition;;
+=> nrel_main_idtf:
+      [Опр. (оптимизация)] (* <- lang_ru;; *);;
+=> nrel_using_constants: 
+	{
+		process;
+		concept_characteristic
+
+	};; 
+<= nrel_sc_text_translation: ... 
+		(*
+			->rrel_example:
+			[Оптимизация - это  <b><sc_element sys_idtf="process">процесс</b> максимизации выходных <b><sc_element sys_idtf="concept_characteristic">характеристик</b> и минимизации расходов.](*<- lang_ru;; =>nrel_format: format_html;;*);;
+		*);;
+*);
+
+
+<- rrel_key_sc_element: ... 
+(*
+ => nrel_main_idtf:
+[Утв. 1 (оптимизация)] (* <- lang_ru;; *);;
+ <= nrel_sc_text_translation: ...
+	 (*
+    	  -> rrel_example:
+		[Оптимизация заключается в <b><sc_element sys_idtf="nrel_search">нахождении</b> наилучшего варианта, <b><sc_element sys_idtf="value">значения</b>.](*<-lang_ru;; =>nrel_format: format_html;;*);;
+	*);;
+=> nrel_using_constants: 
+{
+value;
+nrel_search
+};;
+*);
+
+<-rrel_explored_concept: section_subject_domain_of_mathematical_tasks;;
+

--- a/SD_of_mathematical_tasks/concept_vector_quantization.scs
+++ b/SD_of_mathematical_tasks/concept_vector_quantization.scs
@@ -1,0 +1,49 @@
+concept_vector_quantization
+<-sc_node_not_relation;
+=>nrel_inclusion:concept_mathematical_tasks;
+
+=>nrel_main_idtf:
+[векторное квантование](*<-lang_ru;;*);
+[vector quantization](*<-lang_en;;*);
+
+<- rrel_key_sc_element: ...
+(*
+<- definition;;
+=> nrel_main_idtf:
+      [Опр. (векторное квантование)] (* <- lang_ru;; *);;
+=> nrel_using_constants: 
+	{
+		task;
+		value;
+		number
+
+	};; 
+<= nrel_sc_text_translation: ... 
+		(*
+			->rrel_example:
+			[Векторное квантование - это  <b><sc_element sys_idtf="task">задача</b> о разбиении диапазона отсчётных <b><sc_element sys_idtf="value">значений</b> сигнала на конечное <b><sc_element sys_idtf="number">число</b> уровней и округлениие этих <b><sc_element sys_idtf="value">значений</b> до одного из двух ближайших к ним уровней.](*<- lang_ru;; =>nrel_format: format_html;;*);;
+		*);;
+*);
+
+
+<- rrel_key_sc_element: ... 
+(*
+ => nrel_main_idtf:
+[Утв. 1 (векторное квантование)] (* <- lang_ru;; *);;
+ <= nrel_sc_text_translation: ...
+	 (*
+    	  -> rrel_example:
+		[Векторное квантование представляет собой процесс отображения входных <b><sc_element sys_idtf="value">значений</b> из большего <b><sc_element sys_idtf="set">набора</b> для вывода значений в меньшем, счётном <b><sc_element sys_idtf="set">наборе</b>, часто с конечным <b><sc_element sys_idtf="number">числом</b> элементов.](*<-lang_ru;; =>nrel_format: format_html;;*);;
+	*);;
+=> nrel_using_constants: 
+{
+	value;
+	set;
+	number
+};;
+*);
+
+<-rrel_explored_concept: section_subject_domain_of_mathematical_tasks;;
+
+
+

--- a/SD_of_mathematical_tasks/nrel_compression.scs
+++ b/SD_of_mathematical_tasks/nrel_compression.scs
@@ -1,0 +1,56 @@
+nrel_compression
+<-sc_node_norole_relation;
+
+=>nrel_main_idtf:
+[сжатие входных данных*](*<-lang_ru;;*);
+[compression*](*<-lang_en;;*);
+
+=>nrel_idtf:
+[компрессия*](*<-lang_ru;;*);
+
+<-rrel_key_sc_element: ...
+(*
+	<-definition ;;
+		=> nrel_main_idtf: 
+			[Опр.(сжатие входных данных*)](* <- lang_ru;; *);;
+		=> nrel_using_constants :
+		{
+			nrel_input_layer;
+			set;
+			binary_relation;
+			nrel_strict_inclusion;
+			concept_neural_network_layer
+		};;
+<= nrel_sc_text_translation:...
+	(*
+		-> rrel_example: [Сжатие входных данных - <b><sc_element sys_idtf="binary_relation">бинарное отношение</b> между <b><sc_element sys_idtf="set">множествами</b> элементов <b><sc_element sys_idtf="nrel_input_layer">входного</b> и <b><sc_element sys_idtf="nrel_hidden_nrel_layer">скрытого</b> <b><sc_element sys_idtf="concept_neural_network_layer">слоев нейронной сети</b>, где <b><sc_element sys_idtf="set">множество</b> элементов <b><sc_element sys_idtf="nrel_hidden_nrel_layer">скрытого слоя</b> <b><sc_element sys_idtf="nrel_strict_inclusion">строго включено</b> во <b><sc_element sys_idtf="set">множество</b> элементов <b><sc_element sys_idtf="nrel_input_layer">входного слоя</b>.](*<- lang_ru;; =>nrel_format: format_html;;*);;
+	*);;
+*);
+
+ => nrel_first_domain: input_layer;
+ => nrel_second_domain: hidden_nrel_layer;
+
+ => nrel_definitional_domain:...
+	(*
+		<= nrel_combination: input_layer; hidden_nrel_layer;;
+	*);
+
+<-rrel_key_sc_element: ...
+	(*
+		=> nrel_main_idtf: [Утв.1 (распознавание образов, задача, решение)](* <- lang_ru;; *);;
+		=> nrel_using_constants :
+		{
+			pattern_recognition
+		};;
+		<= nrel_sc_text_translation:...
+		(*
+			-> rrel_example: [Сжатие входных данных производится при решении <b><sc_element sys_idtf="pattern_recognition">задачи распознавания образов</b>.](*<- lang_ru;; =>nrel_format: format_html;;*);;
+		*);;
+*);
+
+<-oriented_relation; antireflexive_relation; transitive_relation; antisymmetric_relation;
+
+<=nrel_inclusion:concept_mathematical_tasks;
+<-rrel_explored_concept: section_subject_domain_of_mathematical_tasks;;
+
+

--- a/SD_of_mathematical_tasks/nrel_decompression.scs
+++ b/SD_of_mathematical_tasks/nrel_decompression.scs
@@ -1,0 +1,53 @@
+nrel_decompression
+<-sc_node_norole_relation;
+=>nrel_main_idtf:[decompression*](* <-lang_en;; *);
+=>nrel_main_idtf:[восстановление входных данных*](* <-lang_ru;; *);
+
+<-rrel_key_sc_element: ...
+(*
+	<-definition ;;
+		=> nrel_main_idtf: 
+			[Опр.(восстановление входных данных*)](* <- lang_ru;; *);;
+		=> nrel_using_constants :
+		{
+			nrel_output_layer;
+			set;
+			binary_relation;
+			nrel_strict_inclusion;
+			concept_neural_network_layer
+		};;
+<= nrel_sc_text_translation:...
+	(*
+		-> rrel_example:[Восстановление входных данных - <b><sc_element sys_idtf="binary_relation">бинарное отношение</b> между множествами элементов <b><sc_element sys_idtf="nrel_hidden_nrel_layer">скрытого</b> и <b><sc_element sys_idtf="nrel_input_layer">выходного</b><b><sc_element sys_idtf="concept_neural_network_layer"> слоев нейронной сети</b>, где <b><sc_element sys_idtf="set">множество</b> элементов <b><sc_element sys_idtf="nrel_hidden_nrel_layer">скрытого слоя</b> <b><sc_element sys_idtf="nrel_strict_inclusion">строго включено</b> во <b><sc_element sys_idtf="set">множество</b> элементов <b><sc_element sys_idtf="nrel_output_layer">выходного слоя</b>.](*<- lang_ru;; =>nrel_format: format_html;;*);;
+	*);;
+*);
+
+ => nrel_first_domain:hidden_nrel_layer;
+ => nrel_second_domain:output_layer;
+
+ => nrel_definitional_domain:...
+	(*
+		<= nrel_combination: hidden_nrel_layer; output_layer;;
+	*);
+
+<-rrel_key_sc_element:...
+	(*
+		=> nrel_main_idtf: [Утв. 1 (распознавание образов, задача, решение)](* <- lang_ru;; *);;
+		=> nrel_using_constants :
+		{
+			pattern_recognition
+		};;
+		<= nrel_sc_text_translation:...
+		(*
+			-> rrel_example: [Восстановление входных данных производится при решении задачи <b><sc_element sys_idtf="pattern_recognition">распознавания образов</b>.](*<- lang_ru;; =>nrel_format: format_html;;*);;
+		*);;
+*);
+
+<-oriented_relation; antireflexive_relation; transitive_relation; antisymmetric_relation;
+
+<=nrel_inclusion:concept_mathematical_tasks;
+<-rrel_explored_concept: section_subject_domain_of_mathematical_tasks;;
+
+
+
+


### PR DESCRIPTION
1) concept_approximation 

Не приблежение, а приближение, везде
убрал concept в основном идентификаторе 
добавил синоним
утверждение в скобки взял

2)concept_decrease_in_dimension

утверждение взял в скобки
перефразировал определение

3)concept_extrapolation

была ссылка на вывод как result, хотя в контексте имеется ввиду логический вывод, убрал ссылку
утверждение взял в скобки

4)concept_increase_in_dimension

перефразировал определение, добавил новую ссылку
утверждение взял в скобки

5)concept_information_compression

был сломанный scs файл и вообще в остис не загружался, переделал, запускается)
не определение а Опр.
и Утв.
добавил ссылки

6)concept_logical_inference

Утв. ()

7)concept_optimization

Утв. ()

8)concept_vector_quantization

в остисе отображается все совсем другое, наверно, где-то в базе есть другая копия?
optimization  для вектрного квантования плохой основной идентификатор, изменил

9)nrel_compression

в остисе другое
добавил синоним
добавил ссылки
перед rrel_key_sc_element добавил <-
в утверждении не было выделено констант

10)nrel_decompression

тоже не компилился в остисе, переделал
добавил синоним
добавил ссылки
в утверждении не было выделено констант



